### PR TITLE
Change sanity check to return 409 error on matching username and password

### DIFF
--- a/src/___tests___/utils.test.js
+++ b/src/___tests___/utils.test.js
@@ -171,10 +171,11 @@ describe('sanityCheck', () => {
     expect(input.message).toEqual('username and password is required');
     expect(input.status).toEqual(400);
   });
-  it('should successfully authenicate the user', () => {
+  it('should successfully authenticate the user', () => {
     const verifyFn = jest.fn(() => true);
     const input = sanityCheck('test', users.test, verifyFn, users, 2);
-    expect(input).toBeTruthy();
-    expect(verifyFn).toHaveBeenCalled();
+    expect(input.status).toEqual(409);
+    expect(input.message).toEqual('username is already registered');
+    expect(verifyFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/___tests___/utils.test.js
+++ b/src/___tests___/utils.test.js
@@ -171,7 +171,7 @@ describe('sanityCheck', () => {
     expect(input.message).toEqual('username and password is required');
     expect(input.status).toEqual(400);
   });
-  it('should successfully authenticate the user', () => {
+  it('should throw error for existing username and password', () => {
     const verifyFn = jest.fn(() => true);
     const input = sanityCheck('test', users.test, verifyFn, users, 2);
     expect(input.status).toEqual(409);

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,7 +132,10 @@ export function sanityCheck(
   if (hash) {
     const auth = verifyFn(password, users[user]);
     if (auth) {
-      return true;
+      err = Error('username is already registered');
+      // $FlowFixMe
+      err.status = 409;
+      return err;
     }
     err = Error('unauthorized access');
     // $FlowFixMe


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type: Bug**

The following has been addressed in the PR: #19 

Allows logging in by calling npm adduser with an existing username and password.
The unit test for this use case is also update to test for the error status and message.

Resolves #19
