### PR TITLE
Bug: adduser success case test does not run assertions

### DIFF
--- a/src/___tests___/htpassed.test.js
+++ b/src/___tests___/htpassed.test.js
@@ -62,9 +62,17 @@ describe('HTPasswd', () => {
   });
 
   it('addUser - it should add the user', done => {
-    fs.writeFile = jest.fn(() => done());
+    let dataToWrite;
+    fs.writeFile = jest.fn((name, data, callback) => {
+      dataToWrite = data;
+      callback();
+    });
     const callback = (a, b) => {
+      expect(a).toBeNull();
+      expect(b).toBeTruthy();
       expect(fs.writeFile).toHaveBeenCalled();
+      expect(dataToWrite.indexOf('usernotpresent')).not.toEqual(-1);
+      done();
     };
     wrapper.adduser('usernotpresent', 'somerandompassword', callback);
   });


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** Bug




**Description: **
The following has been addressed in the PR: The addUser function unit test for the success case stubs the fs.writeFile function to call done(). While the test was not incorrect (writing user to the file will effectively add the user), the test as written might create confusion as other as this will effectively end the test before any of the assertions in the callback are checked.
This PR changes the unit test so that the stub does not call done(), only the callback passed to addUser will call done after all assertions are made. It also adds some assertions on the values passed to the callback and on the data written to the htpasswd file to check if the user was in fact added.
