### PR TITLE
Enforce maximum amount of users for new users only

### DIFF
--- a/src/___tests___/utils.test.js
+++ b/src/___tests___/utils.test.js
@@ -192,4 +192,11 @@ describe('sanityCheck', () => {
     expect(input.message).toEqual('username is already registered');
     expect(verifyFn).toHaveBeenCalledTimes(1);
   });
+  it('should throw error for existing username and password with max number of users reached', () => {
+    const verifyFn = jest.fn(() => true);
+    const input = sanityCheck('test', users.test, verifyFn, users, 1);
+    expect(input.status).toEqual(409);
+    expect(input.message).toEqual('username is already registered');
+    expect(verifyFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -125,13 +125,6 @@ export function sanityCheck(
 
   hash = users[user];
 
-  if (Object.keys(users).length >= maxUsers) {
-    err = Error('maximum amount of users reached');
-    // $FlowFixMe
-    err.status = 403;
-    return err;
-  }
-
   if (hash) {
     const auth = verifyFn(password, users[user]);
     if (auth) {
@@ -143,6 +136,11 @@ export function sanityCheck(
     err = Error('unauthorized access');
     // $FlowFixMe
     err.status = 401;
+    return err;
+  } else if (Object.keys(users).length >= maxUsers) {
+    err = Error('maximum amount of users reached');
+    // $FlowFixMe
+    err.status = 403;
     return err;
   }
 


### PR DESCRIPTION
When the maximum amount of users is reached, verdaccio-htpassword returned a 403 error when existing users tried to login. This PR is supposed to fix that.

Please verify/test before merging, I only performed a manual test (and concluded that this fixes the outlined issue).